### PR TITLE
Added MeshtasticCO Telegram Group and WhatsApp icon updated

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -50,9 +50,14 @@ export default defineConfig({
       },
       social: [
         {
-          icon: "telegram",
+          icon: "phone",
           label: "WhatsApp",
           href: "https://chat.whatsapp.com/Bkw5MiV8RqVL6GRutNyZNS?mode=ac_c",
+        },
+        {
+          icon: "telegram",
+          label: "Telegram",
+          href: "https://t.me/meshtasticco",
         },
         {
           icon: "github",


### PR DESCRIPTION
## Summary

Bonito sitio. Mi primera contribución :) Simplemente por ahora anexo el grupo de Telegram de [MeshtasticCO](https://t.me/meshtasticco) y una propuesta para el inexistente icono de Whatsapp. Aspiro en los próximos días subir o consignar info de lo que hemos construido en documentación hasta ahora en el grupo. Saludos.

Preview:
![screenshot20250802_115405](https://github.com/user-attachments/assets/25d85d9a-7bdf-4540-8c6a-394de3e3e8f2)


